### PR TITLE
docs: add Copilot working preferences

### DIFF
--- a/.agents/skills/code-quality-standards/SKILL.md
+++ b/.agents/skills/code-quality-standards/SKILL.md
@@ -10,6 +10,3 @@ description: Apply this repository's implementation standards whenever writing o
 - Treat every change as public open-source code: make security-conscious commits, avoid exposing secrets or sensitive data, validate untrusted input, preserve authorization boundaries, and do not introduce unnecessarily broad access or origins.
 - Ensure all new frontend UI code is aesthetically designed for both mobile and desktop displays. Verify responsive layout, readable typography, appropriate spacing, usable controls, and the absence of unintended overflow at representative mobile and desktop widths.
 - Add PostHog events for interactions with any new UI elements, using the repository's existing event naming and property conventions.
-- Never merge or push commits directly to `main`. All changes to `main`,
-  including small fixes, infra scripts, and reverts, must go through a pull
-  request.

--- a/.agents/skills/code-quality-standards/SKILL.md
+++ b/.agents/skills/code-quality-standards/SKILL.md
@@ -10,3 +10,6 @@ description: Apply this repository's implementation standards whenever writing o
 - Treat every change as public open-source code: make security-conscious commits, avoid exposing secrets or sensitive data, validate untrusted input, preserve authorization boundaries, and do not introduce unnecessarily broad access or origins.
 - Ensure all new frontend UI code is aesthetically designed for both mobile and desktop displays. Verify responsive layout, readable typography, appropriate spacing, usable controls, and the absence of unintended overflow at representative mobile and desktop widths.
 - Add PostHog events for interactions with any new UI elements, using the repository's existing event naming and property conventions.
+- Never merge or push commits directly to `main`. All changes to `main`,
+  including small fixes, infra scripts, and reverts, must go through a pull
+  request.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Working preferences
+
+- Proceed autonomously on routine, reversible work (e.g. editing code, running
+  existing tests/builds, pushing to a feature/PR branch, merging non-`main`
+  branches into other non-`main` branches). Don't stop to ask for confirmation
+  on these.
+- Only ask a clarifying question when a decision is genuinely ambiguous (multiple
+  reasonable approaches with real tradeoffs), destructive, or hard to undo (e.g.
+  force-pushing over others' work, deleting data, rotating or revoking
+  credentials).
+- When in doubt, prefer taking the reversible/lower-risk action and mentioning what
+  you did, over pausing to ask.
+- **Never merge or push directly to `main`.** All changes to `main` must go
+  through a pull request, even for small fixes, infra scripts, or reverts.
+  Open a PR and let it merge normally instead of committing straight to `main`.


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` so future Copilot sessions in this repo:

- proceed autonomously on routine/reversible work instead of asking for confirmation on everything
- only pause to ask when a decision is genuinely ambiguous or destructive
- **never merge or push directly to `main`** — always go through a PR, even for small fixes

This directly codifies a lesson from this session: a script fix got pushed straight to `main` and a feature branch got squash-merged there when it should have gone through review first.