### PR TITLE
fix: PR preview builds ignored resolved Railway backend URL

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,8 +39,7 @@
       },
       "scripts": {
             "dev": "vite",
-            "prebuild": "node scripts/resolve-pr-backend.mjs",
-            "build": "vite build",
+            "build": "node scripts/build.mjs",
             "test": "vitest run",
             "test:coverage": "vitest run --coverage",
             "vercel:dev": "vercel dev",

--- a/frontend/scripts/build.mjs
+++ b/frontend/scripts/build.mjs
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 /**
- * Runs as an npm `prebuild` hook on Vercel.
+ * Replaces `vite build` as the Vercel build command.
  *
  * When Vercel builds a *preview* deployment for a pull request, Railway (if PR
  * Environments are enabled) spins up a matching temporary backend for that
  * same PR. This script looks up that backend's public domain via the Railway
- * GraphQL API and writes it into `.env.local` as VITE_RAILWAY_API_URL_STAGING,
- * so the preview frontend talks to the PR's own backend instead of the shared
- * `staging` Railway service.
+ * GraphQL API and runs `vite build` with VITE_API_MODE/VITE_RAILWAY_API_URL_STAGING
+ * overridden directly in that build process's environment, so the preview
+ * frontend talks to the PR's own backend instead of the shared `staging`
+ * Railway service.
+ *
+ * A `.env.local` file (or any other env file) can't be used for this: Vite
+ * gives already-set process.env values priority over .env* file contents, and
+ * Vercel already has VITE_RAILWAY_API_URL_STAGING configured as a project env
+ * var for the persistent `staging` backend, so a file-based override would
+ * always lose. Spawning `vite build` with an explicit env object is the only
+ * way to actually win that precedence.
  *
  * It is intentionally best-effort: any failure (missing config, PR
  * environment not up yet, API error, unexpected schema) is logged and the
- * script exits 0 without writing anything, so the build falls back to
- * whatever VITE_RAILWAY_API_URL_STAGING is already configured in Vercel.
+ * build proceeds with the default configured backend.
  *
  * Required Vercel project env vars for this to activate:
  *   RAILWAY_API_TOKEN            - Railway account or workspace token
@@ -21,14 +28,17 @@
  *                                  (defaults to "brickai-backend"; only needed
  *                                  if you rename the Railway service)
  */
-import { writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 const RAILWAY_API_URL = 'https://backboard.railway.com/graphql/v2';
 
 function log(message) {
-  console.log(`[resolve-pr-backend] ${message}`);
+  console.log(`[build] ${message}`);
+}
+
+function runViteBuild(env) {
+  const result = spawnSync('npx', ['vite', 'build'], { stdio: 'inherit', env });
+  process.exit(result.status ?? 1);
 }
 
 async function main() {
@@ -37,6 +47,7 @@ async function main() {
 
   if (vercelEnv !== 'preview' || !prId) {
     log('Not a PR preview build; skipping Railway PR backend lookup.');
+    runViteBuild(process.env);
     return;
   }
 
@@ -49,6 +60,7 @@ async function main() {
       'RAILWAY_API_TOKEN and/or RAILWAY_PROJECT_ID are not set; skipping. ' +
         'Set them as Vercel project env vars to enable per-PR backend resolution.'
     );
+    runViteBuild(process.env);
     return;
   }
 
@@ -94,16 +106,19 @@ async function main() {
     json = await response.json();
     if (!response.ok || json.errors) {
       log(`Railway API request failed: ${response.status} ${JSON.stringify(json.errors)}`);
+      runViteBuild(process.env);
       return;
     }
   } catch (err) {
     log(`Railway API request threw: ${err}`);
+    runViteBuild(process.env);
     return;
   }
 
   const project = json?.data?.project;
   if (!project) {
     log('Railway API response missing project data; skipping.');
+    runViteBuild(process.env);
     return;
   }
 
@@ -121,6 +136,7 @@ async function main() {
       `No Railway environment matching "*${prSuffix}" found yet (it may still be ` +
         `spinning up). Falling back to the default configured backend.`
     );
+    runViteBuild(process.env);
     return;
   }
   const environmentId = prEnv.node.id;
@@ -129,6 +145,7 @@ async function main() {
   const backendService = serviceEdges.find((e) => e.node?.name === serviceName);
   if (!backendService) {
     log(`No Railway service named "${serviceName}" found in this project; skipping.`);
+    runViteBuild(process.env);
     return;
   }
 
@@ -140,22 +157,20 @@ async function main() {
 
   if (!domain) {
     log(`No domain found for service "${serviceName}" in environment "pr-${prId}"; skipping.`);
+    runViteBuild(process.env);
     return;
   }
 
   const backendUrl = `https://${domain}`;
-  const envFilePath = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    '..',
-    '.env.local'
-  );
-  writeFileSync(
-    envFilePath,
-    `VITE_API_MODE=railway_staging\nVITE_RAILWAY_API_URL_STAGING=${backendUrl}\n`
-  );
-  log(`Resolved PR backend to ${backendUrl}; wrote ${envFilePath}.`);
+  log(`Resolved PR backend to ${backendUrl}; building with it.`);
+  runViteBuild({
+    ...process.env,
+    VITE_API_MODE: 'railway_staging',
+    VITE_RAILWAY_API_URL_STAGING: backendUrl,
+  });
 }
 
 main().catch((err) => {
-  log(`Unexpected error, skipping: ${err}`);
+  log(`Unexpected error, falling back to default build: ${err}`);
+  runViteBuild(process.env);
 });


### PR DESCRIPTION
Fixes the root cause behind AI-edit still hitting `brickai-backend-staging.up.railway.app` on PR previews, even though `resolve-pr-backend.mjs` logged that it resolved the correct per-PR Railway URL.

**Root cause:** Vite gives already-set `process.env` values priority over `.env*` file contents. Vercel already has `VITE_RAILWAY_API_URL_STAGING` configured as a project env var pointing at the persistent `staging` Railway backend, so writing the resolved PR-specific URL to `.env.local` could never actually win — Vite silently kept using the pre-existing value at build time.

**Fix:** renamed `resolve-pr-backend.mjs` to `build.mjs`, which now *is* the Vercel build command (`"build": "node scripts/build.mjs"`, no more `prebuild` hook). It resolves the PR backend the same way as before, then spawns `vite build` with the override baked directly into that specific child process's env — which unconditionally wins over any pre-existing Vercel-configured value.

Verified locally: spawning `vite build` with a conflicting `VITE_RAILWAY_API_URL_STAGING` already set in the parent process, the overridden value passed to the child process is the one that ends up in the built bundle, not the parent's pre-existing value.