### PR TITLE
Stream LLM brick-design reasoning to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ npm run test:coverage
 
 This project is licensed under the [MIT License](LICENSE).
 
-> LEGO® is a trademark of the LEGO Group, which does not sponsor, authorize, or endorse this project.
+> LEGO® is a trademark of the LEGO Group, which does not sponsor, authorize, or endorse this project

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -7,7 +7,7 @@ os.environ["OPEN3D_HEADLESS"] = "1"
 os.environ["PYOPENGL_PLATFORM"] = "egl"
 
 from fastapi import FastAPI, Depends, Request, HTTPException, UploadFile, File, Form
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from dotenv import load_dotenv
@@ -22,7 +22,7 @@ from .requests.partToMpd import part_to_mpd, PartToMpdRequest, PartToMpdResponse
 from .requests.ldrToMpd import ldr_to_mpd, LdrToMpdRequest, LdrToMpdResponse
 from .requests.resizeModel import resize_model, ResizeModelRequest, ResizeModelResponse
 from .requests.promptEditModel import prompt_edit_model, PromptEditModelRequest
-from .requests.llmRender import llm_render, LlmRenderRequest, LlmRenderResponse
+from .requests.llmRender import llm_render, llm_render_stream, LlmRenderRequest, LlmRenderResponse
 from .requests.createCheckoutSession import create_checkout_session, CreateCheckoutSessionRequest, CreateCheckoutSessionResponse
 from .requests.stripeWebhook import stripe_webhook, StripeWebhookRequest, StripeWebhookResponse
 from .requests.getGeneration import get_generation, GetGenerationRequest, GetGenerationResponse
@@ -294,6 +294,19 @@ async def llm_render_endpoint(
     the returned semantic recoloring rules, and returns updated xyzrgb content.
     """
     return await llm_render(request, auth_info)
+
+
+@app.post("/llmRender/stream")
+async def llm_render_stream_endpoint(
+    request: LlmRenderRequest,
+    auth_info: dict = Depends(get_user_with_optional_auth),
+) -> StreamingResponse:
+    """Stream brick-design reasoning summaries and the recolored model."""
+    return StreamingResponse(
+        llm_render_stream(request, auth_info),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
 
 
 @app.post("/createCheckoutSession", response_model=CreateCheckoutSessionResponse)

--- a/backend/src/requests/llmRender.py
+++ b/backend/src/requests/llmRender.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import heapq
 import json
@@ -6,7 +7,7 @@ import os
 import re
 from collections import defaultdict
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, Tuple
 
 import httpx
 import numpy as np
@@ -968,6 +969,13 @@ def _extract_json_object(text: str) -> Dict[str, Any]:
     return parsed
 
 
+def _extract_thinking_delta(event: Dict[str, Any]) -> Optional[str]:
+    if event.get("type") != "response.reasoning_summary_text.delta":
+        return None
+    delta = event.get("delta")
+    return delta if isinstance(delta, str) and delta else None
+
+
 def _assignment_schema(segment_ids: List[int]) -> Dict[str, Any]:
     return {
         "type": "object",
@@ -1006,6 +1014,7 @@ async def _call_openai_for_assignments(
     voxel_preview_image_url: str,
     prompt: Optional[str],
     model: str,
+    on_thinking: Optional[Callable[[str], Awaitable[None]]] = None,
 ) -> Tuple[List[Dict[str, Any]], str]:
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
@@ -1022,6 +1031,8 @@ async def _call_openai_for_assignments(
         "reference object each segment is, and give it that part's color. "
         "The reference image is the ONLY source of colors. The colors in the voxel "
         "preview are arbitrary segment IDs, not real colors. Never change geometry. "
+        "Describe your reasoning summary as concise, first-person brick-design observations "
+        "that a model builder can follow, such as identifying parts and their colors. "
         "Return only JSON."
     )
     user_prompt = {
@@ -1063,7 +1074,7 @@ async def _call_openai_for_assignments(
                 ],
             },
         ],
-        "reasoning": {"effort": DEFAULT_REASONING_EFFORT},
+        "reasoning": {"effort": DEFAULT_REASONING_EFFORT, "summary": "auto"},
         "text": {
             "format": {
                 "type": "json_schema",
@@ -1071,20 +1082,41 @@ async def _call_openai_for_assignments(
                 "schema": _assignment_schema(segment_ids),
             }
         },
+        "stream": True,
     }
 
     timeout = httpx.Timeout(OPENAI_TIMEOUT_SECONDS, connect=15.0)
+    response_json: Optional[Dict[str, Any]] = None
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(
+            async with client.stream(
+                "POST",
                 "https://api.openai.com/v1/responses",
                 headers={
                     "Authorization": f"Bearer {api_key}",
                     "Content-Type": "application/json",
                 },
                 json=payload,
-            )
-            response.raise_for_status()
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    data = line[6:]
+                    if data == "[DONE]":
+                        continue
+                    try:
+                        event = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    delta = _extract_thinking_delta(event)
+                    if delta and on_thinking:
+                        await on_thinking(delta)
+                    if event.get("type") == "response.completed" and isinstance(event.get("response"), dict):
+                        response_json = event["response"]
+                    elif event.get("type") == "error":
+                        message = (event.get("error") or {}).get("message", "OpenAI stream failed")
+                        raise HTTPException(status_code=502, detail=message)
     except httpx.HTTPStatusError as e:
         logger.error("OpenAI llmRender request failed: %s", e.response.text)
         raise HTTPException(
@@ -1112,7 +1144,8 @@ async def _call_openai_for_assignments(
             detail=f"OpenAI request failed: {type(e).__name__}: {e}".rstrip(": "),
         )
 
-    response_json = response.json()
+    if response_json is None:
+        raise HTTPException(status_code=502, detail="OpenAI stream ended without a completed response")
     if response_json.get("status") == "incomplete":
         reason = (response_json.get("incomplete_details") or {}).get("reason", "unknown")
         raise HTTPException(status_code=502, detail=f"OpenAI response was incomplete: {reason}")
@@ -1184,7 +1217,11 @@ def _serialize_xyzrgb(voxels: List[Dict[str, int]]) -> str:
     ) + "\n"
 
 
-async def llm_render(request: LlmRenderRequest, auth_info: dict) -> LlmRenderResponse:
+async def llm_render(
+    request: LlmRenderRequest,
+    auth_info: dict,
+    on_thinking: Optional[Callable[[str], Awaitable[None]]] = None,
+) -> LlmRenderResponse:
     endpoint = "/llmRender"
     user_id = auth_info.get("user_email") or auth_info.get("user_id") or "anonymous"
     model = request.model or DEFAULT_MODEL
@@ -1202,6 +1239,7 @@ async def llm_render(request: LlmRenderRequest, auth_info: dict) -> LlmRenderRes
             voxel_preview_image_url=voxel_preview_image_url,
             prompt=request.prompt,
             model=model,
+            on_thinking=on_thinking,
         )
         recolored, applied = _apply_assignments(voxels, segment_ids, assignments)
 
@@ -1244,3 +1282,42 @@ async def llm_render(request: LlmRenderRequest, auth_info: dict) -> LlmRenderRes
             user_id=user_id,
         )
         raise HTTPException(status_code=500, detail=f"llmRender failed: {e}")
+
+
+async def llm_render_stream(
+    request: LlmRenderRequest,
+    auth_info: dict,
+) -> AsyncIterator[str]:
+    queue: asyncio.Queue[Optional[Dict[str, Any]]] = asyncio.Queue()
+
+    async def on_thinking(delta: str) -> None:
+        await queue.put({"type": "thinking", "delta": delta})
+
+    async def run() -> None:
+        try:
+            result = await llm_render(request, auth_info, on_thinking)
+            data = result.model_dump() if hasattr(result, "model_dump") else result.dict()
+            await queue.put({"type": "result", "data": data})
+        except HTTPException as exc:
+            await queue.put({"type": "error", "detail": exc.detail})
+        except Exception:
+            logger.exception("llmRender stream failed")
+            await queue.put({"type": "error", "detail": "LLM render failed"})
+        finally:
+            await queue.put(None)
+
+    task = asyncio.create_task(run())
+    try:
+        while True:
+            event = await queue.get()
+            if event is None:
+                break
+            yield f"data: {json.dumps(event)}\n\n"
+        await task
+    finally:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from src import api
@@ -102,6 +103,16 @@ def test_image_and_text_endpoints_choose_streaming_handler(monkeypatch):
         assert asyncio.run(endpoint(request, AUTH, None)) == "normal"
         request.stream = True
         assert asyncio.run(endpoint(request, AUTH, None)) == "stream"
+
+
+def test_llm_render_stream_endpoint_wraps_handler(monkeypatch):
+    async def events():
+        yield 'data: {"type":"thinking","delta":"Building"}\n\n'
+
+    monkeypatch.setattr(api, "llm_render_stream", lambda request, auth: events())
+    response = asyncio.run(api.llm_render_stream_endpoint("request", AUTH))
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "text/event-stream"
 
 
 def test_unprotected_one_argument_endpoints(monkeypatch):

--- a/backend/tests/test_llm_render.py
+++ b/backend/tests/test_llm_render.py
@@ -1,4 +1,7 @@
+import asyncio
 import base64
+import importlib
+import json
 import sys
 from io import BytesIO
 from pathlib import Path
@@ -15,8 +18,11 @@ from src.requests.llmRender import (
     _assignment_schema,
     _build_scene_summary,
     _build_voxel_preview_data_url,
+    _extract_thinking_delta,
     _geometric_regions,
     _load_font,
+    LlmRenderResponse,
+    llm_render_stream,
     _perceptual_colors,
     _project_segments,
     _quantize_colors,
@@ -398,6 +404,43 @@ def test_assignment_schema_requires_every_segment():
     assert assignments["minItems"] == 3
     assert assignments["maxItems"] == 3
     assert assignments["items"]["properties"]["segment_id"]["enum"] == [1, 2, 3]
+
+
+def test_extract_thinking_delta_only_returns_reasoning_summaries():
+    assert _extract_thinking_delta(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "delta": "I notice the torso should use red bricks.",
+        }
+    ) == "I notice the torso should use red bricks."
+    assert _extract_thinking_delta({"type": "response.output_text.delta", "delta": "private output"}) is None
+    assert _extract_thinking_delta({"type": "response.reasoning_summary_text.delta", "delta": 3}) is None
+
+
+def test_llm_render_stream_relays_thinking_and_result(monkeypatch):
+    async def fake_llm_render(_request, _auth_info, on_thinking):
+        await on_thinking("I see separate arms and a torso.")
+        return LlmRenderResponse(
+            xyzrgb_content="0 0 0 255 0 0\n",
+            voxel_count=1,
+            segment_count=1,
+            model="test-model",
+            applied_rules=[],
+        )
+
+    module = importlib.import_module("src.requests.llmRender")
+    monkeypatch.setattr(module, "llm_render", fake_llm_render)
+
+    async def collect_events():
+        return [event async for event in llm_render_stream(object(), {})]
+
+    events = [
+        json.loads(event.removeprefix("data: "))
+        for event in asyncio.run(collect_events())
+    ]
+    assert events[0] == {"type": "thinking", "delta": "I see separate arms and a torso."}
+    assert events[1]["type"] == "result"
+    assert events[1]["data"]["xyzrgb_content"] == "0 0 0 255 0 0\n"
 
 
 def test_apply_assignments_recolors_segments_and_ignores_invalid_entries():

--- a/frontend/src/pages/GeneratedModel.tsx
+++ b/frontend/src/pages/GeneratedModel.tsx
@@ -249,6 +249,7 @@ export default function GeneratedModel() {
   const [editPromptError, setEditPromptError] = React.useState<string | null>(null);
   const [isLlmEditing, setIsLlmEditing] = React.useState(false);
   const [llmEditError, setLlmEditError] = React.useState<string | null>(null);
+  const [llmThinking, setLlmThinking] = React.useState("");
   
   // Voxel editor state
   const [showVoxelEditor, setShowVoxelEditor] = React.useState(false);
@@ -1579,6 +1580,7 @@ export default function GeneratedModel() {
 
     setIsLlmEditing(true);
     setLlmEditError(null);
+    setLlmThinking("");
 
     try {
       let referenceImageUrl = processedImageUrl;
@@ -1594,11 +1596,12 @@ export default function GeneratedModel() {
         throw new Error('No reference image found for this generation');
       }
 
-      const llmResponse = await LlmRenderApiService.llmRender(
+      const llmResponse = await LlmRenderApiService.llmRenderStream(
         xyzrgbUrl,
         referenceImageUrl,
         'Recolor the voxel model to semantically match the reference image while preserving the model shape.',
-        accessToken || undefined
+        accessToken || undefined,
+        (delta) => setLlmThinking((current) => current + delta),
       );
 
       setXyzrgbContent(llmResponse.xyzrgb_content);
@@ -2300,6 +2303,15 @@ export default function GeneratedModel() {
                     </>
                   )}
               </button>
+              {isLlmEditing && llmThinking && (
+                <div
+                  aria-live="polite"
+                  className="w-full max-w-sm rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm text-slate-700 shadow-sm sm:max-w-md"
+                >
+                  <p className="mb-1 font-semibold text-slate-900">AI design notes</p>
+                  <p className="whitespace-pre-wrap break-words">{llmThinking}</p>
+                </div>
+              )}
 
               {/* Edit Model button — white with grey border, turns red on hover */}
               <button

--- a/frontend/src/services/llmRenderApi.ts
+++ b/frontend/src/services/llmRenderApi.ts
@@ -82,4 +82,71 @@ export class LlmRenderApiService {
 
     return data;
   }
+
+  static async llmRenderStream(
+    xyzrgbUrl: string,
+    referenceImageUrl: string,
+    prompt?: string,
+    accessToken?: string,
+    onThinking?: (delta: string) => void,
+  ): Promise<LlmRenderResponse> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (accessToken) {
+      headers.Authorization = 'Bearer ' + accessToken;
+    }
+
+    const response = await fetch(`${API_BASE_URL}/llmRender/stream`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        xyzrgb_url: xyzrgbUrl,
+        reference_image_url: referenceImageUrl,
+        prompt,
+      } satisfies LlmRenderRequest),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`API request failed: ${response.status} ${response.statusText}. ${errorText}`);
+    }
+    if (!response.body) {
+      throw new Error('Response body is null — streaming not supported by browser');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let result: LlmRenderResponse | undefined;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+
+      while (buffer.includes('\n\n')) {
+        const delimiterIndex = buffer.indexOf('\n\n');
+        const rawEvent = buffer.slice(0, delimiterIndex);
+        buffer = buffer.slice(delimiterIndex + 2);
+        if (!rawEvent.startsWith('data: ')) continue;
+
+        const event = JSON.parse(rawEvent.slice(6)) as
+          | { type: 'thinking'; delta: string }
+          | { type: 'result'; data: LlmRenderResponse }
+          | { type: 'error'; detail: string };
+        if (event.type === 'thinking') {
+          onThinking?.(event.delta);
+        } else if (event.type === 'result') {
+          result = event.data;
+        } else if (event.type === 'error') {
+          throw new Error(event.detail);
+        }
+      }
+
+      if (done) break;
+    }
+
+    if (!result?.xyzrgb_content) {
+      throw new Error('LLM render stream ended without a result');
+    }
+    return result;
+  }
 }

--- a/frontend/tests/services.test.ts
+++ b/frontend/tests/services.test.ts
@@ -19,6 +19,12 @@ import { UpdateUsernameApiService, UsernameTakenError } from '../src/services/up
 
 const ok = (data: unknown) => ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue(data), text: vi.fn() });
 const fail = (status = 400, text = 'bad request') => ({ ok: false, status, statusText: 'Bad Request', json: vi.fn(), text: vi.fn().mockResolvedValue(text) });
+const sse = (chunks: string[]) => new ReadableStream({
+  start(controller) {
+    chunks.forEach((chunk) => controller.enqueue(new TextEncoder().encode(chunk)));
+    controller.close();
+  },
+});
 
 describe('JSON API service contracts', () => {
   beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
@@ -75,6 +81,27 @@ describe('JSON API service contracts', () => {
     await expect(UpdateModelApiService.updateModel('g', 'xyz')).rejects.toThrow('API error: 500 - broken');
     vi.mocked(fetch).mockResolvedValueOnce(fail(409, 'taken') as unknown as Response);
     await expect(UpdateUsernameApiService.updateUsername('taken')).rejects.toBeInstanceOf(UsernameTakenError);
+  });
+
+  it('streams LLM brick-design thinking before returning the result', async () => {
+    const result = { xyzrgb_content: 'xyz', voxel_count: 1, segment_count: 1, model: 'm', applied_rules: [], message: 'ok' };
+    const thinking = vi.fn();
+    const stream = sse([
+      'data: {"type":"thinking","delta":"I see a red "}\n',
+      '\ndata: {"type":"thinking","delta":"torso."}\n\n',
+      `data: ${JSON.stringify({ type: 'result', data: result })}\n\n`,
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce({ ...ok({}), body: stream } as unknown as Response);
+
+    await expect(LlmRenderApiService.llmRenderStream('xyz', 'image', 'paint', 'tok', thinking)).resolves.toEqual(result);
+    expect(thinking.mock.calls.flat()).toEqual(['I see a red ', 'torso.']);
+    expect(String(vi.mocked(fetch).mock.calls[0][0]).endsWith('/llmRender/stream')).toBe(true);
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ...ok({}),
+      body: sse(['data: {"type":"error","detail":"Model unavailable"}\n\n']),
+    } as unknown as Response);
+    await expect(LlmRenderApiService.llmRenderStream('xyz', 'image')).rejects.toThrow('Model unavailable');
   });
 
   it('validates required values before making requests', async () => {


### PR DESCRIPTION
AI model edits previously returned only after the LLM completed, leaving users without insight into its design analysis. This adds live, brick-focused reasoning summaries during processing.

- **Backend streaming**
  - Request user-safe OpenAI reasoning summaries.
  - Add an SSE endpoint that emits `thinking`, `result`, and `error` events.
  - Preserve the existing JSON endpoint for compatibility.

- **Client experience**
  - Parse streamed events while retaining the existing response contract.
  - Display accumulated observations as responsive, accessible “AI design notes.”

```text
I see separate arms, legs, a torso, and a head.
I notice the torso should be made from red bricks.
```

- **Coverage**
  - Cover reasoning-summary filtering, SSE event generation, chunked client parsing, and streamed errors.

- Fixes #68

---
Third time recreating this PR (originally #69, then #76). Both landed on `main` sooner than intended. **This PR is based on #79 (the revert) and should be merged after #79, not before** — merging this before #79 would just be a no-op against current `main`. Verified: backend pytest (82 passed), frontend vitest (19 passed), and `npm run build` all pass.